### PR TITLE
Adjust slider height independent of button size

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ if (UIManager.setLayoutAnimationEnabledExperimental) {
 
 const propTypes = {
   buttonSize: PropTypes.number.isRequired,
+  sliderHeight: PropTypes.number,
   backgroundColor: PropTypes.string,
   buttonColor: PropTypes.string,
   text: PropTypes.string,
@@ -129,6 +130,7 @@ export default class RNSwipeVerify extends Component {
     const {
       buttonColor,
       buttonSize,
+      sliderHeight,
       borderColor,
       backgroundColor,
       icon,
@@ -146,7 +148,7 @@ export default class RNSwipeVerify extends Component {
           borderRadius: borderRadius + 4,
           padding: 2,
           flex: 1,
-          height: buttonSize+4
+          height: sliderHeight ? sliderHeight : buttonSize + 4
         }}
       >
         <View
@@ -159,7 +161,7 @@ export default class RNSwipeVerify extends Component {
           }}
           style={{
             backgroundColor,
-            height: buttonSize,
+            height: sliderHeight ? sliderHeight : buttonSize,
             borderRadius,
             justifyContent: "center"
           }}
@@ -181,7 +183,7 @@ export default class RNSwipeVerify extends Component {
               position,
               {
                 width: buttonSize,
-                height: buttonSize,
+                height: sliderHeight ? sliderHeight : buttonSize,
                 borderRadius: borderRadius,
                 backgroundColor: buttonColor,
                 justifyContent: "center",


### PR DESCRIPTION
### Added
- Optional `sliderHeight` prop to adjust slider height independent of button size

This change is backwards compatible and will not affect existing logic because it defaults to `buttonSize` for height if no `sliderHeight` prop is passed.

---
For our usecase, we needed to make the slider button bigger to accommodate text but it would make the slider bigger than we needed it to be. 

<img width="453" alt="Screen Shot 2019-11-06 at 6 17 49 PM" src="https://user-images.githubusercontent.com/4522508/68346353-ec37f600-00c1-11ea-80e7-1945ed37cc59.png">



